### PR TITLE
Adding methods to get lag from consumer

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -519,6 +519,24 @@ class BalancedConsumer():
         log.debug("Rebalance triggered by topic change")
         self._rebalance()
 
+    def get_last_committed_offsets(self):
+        """Get the offsets of the consumer
+        
+        :returns dict with partition id as key and offset of the partition as value
+        """
+        if not self._consumer:
+            raise ConsumerStoppedException("Internal consumer is stopped")
+        return self._consumer.get_last_committed_offsets()
+
+    def get_partition_lags(self):
+        """Get the number of pending messages per partition for the consumer
+        
+        :returns dict with partition id as key and lag of the partition as value
+        """
+        if not self._consumer:
+            raise ConsumerStoppedException("Internal consumer is stopped")
+        return self._consumer.get_partition_lags()
+    
     def reset_offsets(self, partition_offsets=None):
         """Reset offsets for the specified partitions
 


### PR DESCRIPTION
@vernonm @zsimpson 

Check this code, if you agree with all, will make the pull request on their repo.

Example of use:

import json
import time
import sys
import common
sys.path.insert(0, "pykafka")
from pykafka import KafkaClient
from pykafka import protocol
import logging
import sys

root = logging.getLogger()
root.setLevel(logging.WARN)

ch = logging.StreamHandler(sys.stdout)
ch.setLevel(logging.WARN)
formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
ch.setFormatter(formatter)
root.addHandler(ch)

topic_name = "test2"
group = "group0"

kafka = KafkaClient(hosts='ip-10-10-0-92.ec2.internal:31000')
topic = kafka.topics[topic_name]
consumer = topic.get_balanced_consumer(consumer_group=group, auto_commit_enable=False, zookeeper_connect="localhost:2181")

print consumer.get_partition_lags()
